### PR TITLE
Add data-skip-router

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -141,6 +141,10 @@ Router.prototype.onClick = function (e, el) {
 		return;
 	}
 
+	if (el.hasAttribute('data-skip-router')) {
+		return;
+	}
+
 	// We are all good to parse the route
 	e.preventDefault();
 

--- a/test/router.js
+++ b/test/router.js
@@ -62,6 +62,18 @@ describe('Router', function () {
 		router.onClick(evt, evt.target);
 	});
 
+	it('should not intercept clicks when data-skip-router is specified', function () {
+		router._processRequest = function () {
+			throw new Error('Should not have been called!!');
+		};
+
+		evt.target = document.createElement('a');
+		evt.target.setAttribute('href', '/foo');
+		evt.target.setAttribute('data-skip-router', '');
+
+		router.onClick(evt, evt.target);
+	});
+
 	it('should intercept clicks', function (done) {
 		router.get('/foo', function (req, res) {
 			done();


### PR DESCRIPTION
Allow skipping the router by specifying a special
data-skip-router attribute on a local link

In some cases it's useful to have an a element that doesn't go through the router, because it is handled in a different or special way.

In my use case normal routing calls the server (via ajax) to fetch data for the next page, but some pages are closely related (for example multiple tabs), so when a user enters one tab I load all data for all tabs. Changing tabs now no longer has to go through the normal router middleware to fetch all data.
This change allows me to mark the tab links as `a` elements that skip the router, AND handle them separately with onClick handler.
