### PR TITLE
Fixes routers with a base path improperly setting req.path to the full url

### DIFF
--- a/example/base-dir/client.js
+++ b/example/base-dir/client.js
@@ -1,4 +1,3 @@
-require('../../lib/polyfills');
 var router = require('../../')({base: '/base'});
 var routes = require('./routes');
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -203,7 +203,7 @@ Router.prototype._processRequest = function (url, replace) {
 	req.method = 'GET';
 	req.originalUrl = url.pathname + url.search + url.hash;
 	req.baseUrl = this._base;
-	req.path = url.pathname;
+	req.path = path;
 	req.url = this.currentLocation + url.hash;
 
 	// Create the response object

--- a/test/router.js
+++ b/test/router.js
@@ -22,6 +22,16 @@ describe('Router', function () {
 		assert.equal(router.base(), p, 'Did not set and get base path');
 	});
 
+	it('should correctly set path with a base path', function (done) {
+		router.base('/test');
+		router.use(function (req, res) {
+			assert.equal(req.path, '/foo', 'Failed to set req.path with a base path');
+			done();
+		});
+		router.listen({dispatch: false});
+		router.changeRoute('/test/foo');
+	});
+
 	it('should start register routes like the base router', function () {
 		router.use(function () {});
 		router.get('/', function () {});


### PR DESCRIPTION
Express sets `req.path` to the sub app scoped path.  Nighthawk was incorrectly setting it to the full url.  This fixes that, but makes this a breaking change.