### PR TITLE
Switch to `qs` module, but lazy load it

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -8,11 +8,20 @@
 var BaseRouter = require('router');
 var inherits = require('inherits');
 var url = require('url');
-var qs = require('querystring');
 var interceptClicks = require('intercept-link-clicks');
 var Request = require('./request');
 var Response = require('./response');
 var supported = require('./supports-push-state');
+
+// Lazy load query string parser
+var qs = {};
+var _qs;
+Object.defineProperty(qs, 'parse', {
+	get: function () {
+		_qs = _qs || require('q' + 's');
+		return _qs.parse;
+	}
+});
 
 /**
  * Router

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "size": "stat -f \"File size: %z bytes gzipped\" dist/nighthawk.min.js.gz",
     "test": "happiness && mochify -r qs --grep 'BROWSER: ' --invert",
     "test-cover": "mochify --cover",
-    "test-browser": "happiness && mochify --wd",
+    "test-browser": "happiness && mochify --wd -r qs",
     "example-basic": "cd example/basic && npm install && npm run browserify && npm run start",
     "example-basedir": "cd example/base-dir && npm install && npm run browserify && npm run start",
     "example-redirect": "cd example/redirect && npm install && npm run browserify && npm run start",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "browserify": "^14.1.0",
     "disc": "^1.3.2",
     "happiness": "^7.1.2",
-    "mochify": "^3.1.0",
+    "mochify": "^3.1.1",
     "qs": "^6.4.0",
     "uglify-js": "^2.8.16"
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "minify": "uglifyjs dist/nighthawk.js -mc -o dist/nighthawk.min.js",
     "gzip": "gzip -c dist/nighthawk.min.js > dist/nighthawk.min.js.gz",
     "size": "stat -f \"File size: %z bytes gzipped\" dist/nighthawk.min.js.gz",
-    "test": "happiness && mochify --grep 'BROWSER: ' --invert",
+    "test": "happiness && mochify -r qs --grep 'BROWSER: ' --invert",
     "test-cover": "mochify --cover",
     "test-browser": "happiness && mochify --wd",
     "example-basic": "cd example/basic && npm install && npm run browserify && npm run start",
@@ -44,6 +44,7 @@
     "disc": "^1.3.2",
     "happiness": "^7.1.2",
     "mochify": "^3.1.0",
+    "qs": "^6.4.0",
     "uglify-js": "^2.8.16"
   }
 }

--- a/test/router.js
+++ b/test/router.js
@@ -9,7 +9,7 @@ describe('Router', function () {
 			window.history.pushState('/', null, '/');
 			router.destroy();
 		}
-		router = Router();
+		router = new Router();
 
 		evt = {
 			which: 1,
@@ -119,5 +119,17 @@ describe('Router', function () {
 		};
 
 		router.changeRoute('/foo?bar=bar#baz');
+	});
+
+	it('should parse the query string', function (done) {
+		router = new Router({
+			parseQuerystring: true
+		});
+
+		router.use(function (req, res) {
+			assert.equal(req.query.foo, 'bar');
+			done();
+		});
+		router.changeRoute('/test?foo=bar');
 	});
 });


### PR DESCRIPTION
The `qs` module is what express uses, but it is larger than the `querystring` module, so I made it a dev dependency, and you have to manually load it if you want to use it.