### PR TITLE
v2.0

### DIFF
--- a/.min-wd
+++ b/.min-wd
@@ -7,7 +7,6 @@
   }, {
     "name": "firefox"
   }, {
-    "name": "internet explorer",
-	"version": "10"
+    "name": "MicrosoftEdge"
   }]
 }

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,5 @@ npm-debug.log
 test
 .travis.yml
 .min-wd
+.gitignore
+dist/nighthawk.min.js.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "1.8"
-  - "2.5"
-  - "3.3"
-  - '4.2'
-  - '5.5'
+  - '7.0'
 
 env:
   global:
@@ -13,5 +8,4 @@ env:
     - secure: "BQRIKyk7XSk7kNzXHq3iKz8Gr7I3WeaR7BwLdpHNeipJR+pLfSLtD2UVxKZJ1WAB4HC/lz5NUYOm3d+BhhOSSZKpPCCJRX44DmMhVAg7Z8htBkm1jIBnmZbrYW9irfnpy1mCjcvfirIak2lcKwo3KBNCC1zME4529wiEwyU4HWaFLJUmpYsVOGNdwMdn3b5YNxlpz4F78PKCHiGWoZYfC0fPiXGbKzSm7PlbjK07KWqZ7nCX1c99lnpDuuEEvD2sbQMye8NicwaXff9TKKYT4m3hxtyJpHv1dcUuB0wjJSoVVJmtPLR7DgZ3EwSCdH7ZN9KSMiGmN6BtuSL8GnVAdX2KKj4/46pvA1q6ZnXWDymwMTc4f4qOV2VFQ2Z/FO/vVv4x2axsJ4WQFld826FDnA8YagSW9Dae1pNCNHuLibZkxiTwCtYJq2/3zbbO6TmvQM0P2b7E4ot7MzhAwSI2zhAmIxPIkecnXFhpueegYKqX7uNnSmW2SOYoMUOvnOUzvXSZhndPLmboCuSdTW0c/FDyH8/mjInXt8hWEG8Xdr2/VpPvgs7pMW/bc27vZ+rqIfLWA0wf68nOeIQwlFUcoyQVc9lr26MU9fJEQHPkuqUjZ8EYhPYnS4mQIiwStSPr7W2TXgfRYPjRHnlEMZvA9hSICLsj5z0OlZ1JrfATc04="
 
 script:
-  - 'npm test'
-  - 'if [ "x$TRAVIS_NODE_VERSION" = "x5.5" ]; then npm run test-browser; fi'
+    - 'npm run test-browser'

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015, Wes Todd
+Copyright (c) 2015-17, Wes Todd
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# A wrapper around Express' router for the browser
+# Express' Router for the Browser
 
 [![NPM Version][npm-image]][npm-url]
 [![NPM Downloads][downloads-image]][downloads-url]
@@ -6,11 +6,18 @@
 [![js-happiness-style](https://img.shields.io/badge/code%20style-happiness-brightgreen.svg)](https://github.com/JedWatson/happiness)
 [![Sauce Test Status](https://saucelabs.com/buildstatus/wesleytodd123)](https://saucelabs.com/u/wesleytodd123)
 
-The Express Router is great!  It is reliable and really simple.  With Express 5.0 the router module was pulled out into a stand-alone package, so I figured, why not see if it runs in the browser.  Sure enough, it did!  So this is a wrapper around the [Express Router](https://github.com/pillarjs/router) package that layers on browser push state based location updates.  I was heavily influenced by [Page.js](https://visionmedia.github.io/page.js/) and use a very similar method to transparently catch page changes events.
+The Express Router is great!  It is reliable and really simple.  With Express 5.0 the router module was pulled out into a stand-alone package, 
+so I figured, why not see if it runs in the browser.  Sure enough, it did!  So this is a wrapper around the [Express Router](https://github.com/pillarjs/router) 
+package that layers on browser push state based location updates.  I was heavily influenced by [Page.js](https://visionmedia.github.io/page.js/) and use a 
+very similar method to transparently catch page changes events.
 
-Unlike some other recent front-end routing attempts _(\*\*cough react-router, angular-ui-router and ember router cough\*\*)_ <sup>[1](#fn1)</sup>, this package requires no special integration points into your links and no special methods to call to change routes.  It layers transparently over your existing application and catches link clicks which cause route changes.
+Unlike some other recent front-end routing attempts _(\*\*cough react-router, angular-ui-router and ember router cough\*\*)_ <sup>[1](#fn1)</sup>, this 
+package requires no special integration points into your links and no special methods to call to change routes.  It layers transparently over your existing 
+application and catches link clicks which cause route changes.
 
-It is also relatively small, weighing in at 19kb minified and gzipped.  If you are using browserify you are probably already bundling modules like `buffer` and `process`, so if you don't count those we only add 8kb total.  This is a fair bit smaller than other comparable libraries for front-end routing.  You can see for yourself by running `npm run disc`, which will open a breakdown of where the file size comes from and display the minified and gzipped file size (`File size: 8198 bytes gzipped`).
+It is also relatively small, weighing in at 19kb minified and gzipped.  If you are using browserify you are probably already bundling modules like `buffer` 
+and `process`, so if you don't count those we only add 8kb total.  This is a fair bit smaller than other comparable libraries for front-end routing.  You 
+can see for yourself by running `npm run disc`, which will open a breakdown of where the file size comes from and display the minified and gzipped file size (`File size: 8198 bytes gzipped`).
 
 **NOTE**: Requires HTML5 `history` api, aka `pushState`.  This module does not support hash based routing (who is actually supporting IE9 anymore anyway? Not even Microsoft is...).
 
@@ -30,9 +37,10 @@ router.get('/:foo', function(req, res) {
 router.listen();
 ```
 
-### Setting A Base Directory
+### Setting A Base Path
 
-Nighthawk supports service applications that are not hosted at the root of your domain via `base`.  To set a base directory just pass it in to the router constructor.  For example:
+Nighthawk supports service applications that are not hosted at the root of your domain via `base`.  To set a base path just pass it in to 
+the router constructor.  For example:
 
 ```javascript
 var Nighthawk = require('nighthawk');
@@ -41,7 +49,7 @@ var router = new Nighthawk({
 	base: '/foo'
 });
 
-// Optionally you can also set the base directory
+// Optionally you can also set the base path
 // with `router.base('/foo')`.
 
 router.get('/bar', function(req, res) {
@@ -52,7 +60,8 @@ router.listen();
 
 ### What happens when `history` is not supported
 
-It just falls back to basic HTML link behavior.  Thats the great thing about this pattern, it builds on top of basic building blocks of the web.  Also, if it is not supported, your route will still run, so you can still use Nighthawk to kick off your application in unsupported browsers.
+It just falls back to basic HTML link behavior.  Thats the great thing about this pattern, it builds on top of basic building blocks of the web.  Also, 
+if it is not supported, your route will still run, so you can still use Nighthawk to kick off your application in unsupported browsers.
 
 ### Run the examples
 
@@ -70,7 +79,8 @@ Visit [http://localhost:1234](http://localhost:1234).
 $ npm test
 ```
 
-<a name="fn1" href="#fn1">[1]</a>: In opinionated frameworks this is not really that big of a deal because you are already tied down to an ecosystem that probably works really well.  But in a "pick your own adventure" style application it is much nicer to have less coupling.
+<a name="fn1" href="#fn1">[1]</a>: In opinionated frameworks this is not really that big of a deal because you are already tied down 
+to an ecosystem that probably works really well.  But in a "pick your own adventure" style application it is much nicer to have less coupling.
 
 [npm-image]: https://img.shields.io/npm/v/nighthawk.svg
 [npm-url]: https://npmjs.org/package/nighthawk

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It is also relatively small, weighing in at 19kb minified and gzipped.  If you a
 and `process`, so if you don't count those we only add 8kb total.  This is a fair bit smaller than other comparable libraries for front-end routing.  You 
 can see for yourself by running `npm run disc`, which will open a breakdown of where the file size comes from and display the minified and gzipped file size (`File size: 8198 bytes gzipped`).
 
-**NOTE**: Requires HTML5 `history` api, aka `pushState`.  This module does not support hash based routing (who is actually supporting IE9 anymore anyway? Not even Microsoft is...).
+**NOTE**: Requires HTML5 `history` api, aka `pushState`.  This module does not support hash based routing.
 
 ### Example:
 

--- a/example/basic/client.js
+++ b/example/basic/client.js
@@ -1,4 +1,3 @@
-require('../../lib/polyfills');
 var router = require('../../')();
 var routes = require('./routes');
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // Expose the Router constructor
 module.exports = require('./lib/router');
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @file request.js
  * @author Wes Todd

--- a/lib/request.js
+++ b/lib/request.js
@@ -16,8 +16,11 @@ var Request = module.exports = function Request () {
 	this.method = null;
 	this.baseUrl = null;
 	this.originalUrl = null;
-	this.protocol = window.location.protocol;
 	this.path = null;
+
+	// Chop off the :
+	var _proto = window.location.protocol;
+	this.protocol = _proto.slice(0, _proto.length - 1);
 };
 
 // Noops for parity with backend request object

--- a/lib/request.js
+++ b/lib/request.js
@@ -5,6 +5,11 @@
  * @module nighthawk
  */
 
+var EventEmitter = require('events');
+var inherits = require('inherits');
+var _loc = typeof window !== 'undefined' && window.location;
+var noop = function noop () {};
+
 /**
  * Request
  *
@@ -13,16 +18,42 @@
  */
 var Request = module.exports = function Request () {
 	this.app = null;
-	this.url = '';
+	this.url = null;
 	this.method = null;
 	this.baseUrl = null;
 	this.originalUrl = null;
 	this.path = null;
+	this.hostname = _loc.hostname;
+	this.protocol = _loc.protocol.slice(0, _loc.protocol.length - 1);
+	this.secure = this.protocol === 'https';
 
-	// Chop off the :
-	var _proto = window.location.protocol;
-	this.protocol = _proto.slice(0, _proto.length - 1);
+	// This is more basic than the one in express, but I think
+	// that is alright for now because that one uses the a method
+	// from the c++ portion of the net package
+    this.subdomains = this.hostname.split('.').reverse().slice(2);
+
+	// Most of these do not apply on the front-end
+	this.socket = null;
+	this.httpVersion = '1.1';
+	this.rawHeaders = [];
+	this.headers = {};
+	this.rawTrailers = [];
+	this.trailers = {};
+	this.ip = '';
+	this.ips = [];
+	this.fresh = true;
+	this.stale = false;
+	this.xhr = false;
 };
+inherits(Request, EventEmitter);
 
 // Noops for parity with backend request object
-Request.prototype.header = function () {};
+Request.prototype.header =
+Request.prototype.get =
+Request.prototype.accepts =
+Request.prototype.acceptsEncodings =
+Request.prototype.acceptsCharsets =
+Request.prototype.acceptsLanguages =
+Request.prototype.range =
+Request.prototype.is =
+noop;

--- a/lib/request.js
+++ b/lib/request.js
@@ -47,9 +47,22 @@ var Request = module.exports = function Request () {
 };
 inherits(Request, EventEmitter);
 
-// Noops for parity with backend request object
 Request.prototype.header =
-Request.prototype.get =
+Request.prototype.get = function (name) {
+	if (typeof name !== 'string') {
+		throw new TypeError('name must be a string to req.get');
+	}
+	var lc = name.toLowerCase();
+	switch (lc) {
+		case 'referer':
+		case 'referrer':
+			return document.referrer;
+		case 'content-type':
+			return document.contentType;
+	}
+};
+
+// Noops for parity with backend request object
 Request.prototype.accepts =
 Request.prototype.acceptsEncodings =
 Request.prototype.acceptsCharsets =

--- a/lib/request.js
+++ b/lib/request.js
@@ -30,7 +30,7 @@ var Request = module.exports = function Request () {
 	// This is more basic than the one in express, but I think
 	// that is alright for now because that one uses the a method
 	// from the c++ portion of the net package
-    this.subdomains = this.hostname.split('.').reverse().slice(2);
+	this.subdomains = this.hostname.split('.').reverse().slice(2);
 
 	// Most of these do not apply on the front-end
 	this.socket = null;

--- a/lib/response.js
+++ b/lib/response.js
@@ -34,12 +34,20 @@ inherits(Response, EventEmitter);
  * @function redirect
  * @memberof module:nighthawk.Response
  * @instance
+ * @param {Number} statusCode - Optional status code discarded by nighthawk but handled for backend parity
  * @param {String} u - The new url
  */
-Response.prototype.redirect = function (u) {
+Response.prototype.redirect = function (statusCode, u) {
 	// In a timeout because page.js did it, but I believe it is better
 	// to let the current route handler finish its stuff before starting
 	// another round of routing, otherwise we could get some weird behavior.
+
+	if (typeof statusCode === 'string') {
+		u = statusCode;
+		statusCode = 302;
+	}
+	this.status(statusCode);
+
 	setTimeout(function () {
 		// Convert the url string into an object
 		// before passing it along to the router

--- a/lib/response.js
+++ b/lib/response.js
@@ -5,8 +5,10 @@
  * @module nighthawk
  */
 
-// Requirements
+var EventEmitter = require('events');
+var inherits = require('inherits');
 var url = require('url');
+var noop = function noop () {};
 
 /**
  * Response
@@ -16,8 +18,15 @@ var url = require('url');
  */
 var Response = module.exports = function Response () {
 	this.app = null;
-	this.locals = {};
+	this.locals = Object.create(null);
+	this.headersSent = false;
+	this.statusCode = null;
+	this.statusMessage = '';
+	this.finished = false;
+	this.headersSent = false;
+	this.sendDate = false;
 };
+inherits(Response, EventEmitter);
 
 /**
  * Redirect to a different route
@@ -38,3 +47,43 @@ Response.prototype.redirect = function (u) {
 		this.app._processRequest(u, true);
 	}.bind(this), 0);
 };
+
+Response.prototype.status = function (code) {
+	this.statusCode = code;
+	return this;
+};
+
+// Noops for parity with backend request object
+Response.prototype.links =
+Response.prototype.send =
+Response.prototype.json =
+Response.prototype.jsonp =
+Response.prototype.sendStatus =
+Response.prototype.sendFile =
+Response.prototype.download =
+Response.prototype.contentType =
+Response.prototype.type =
+Response.prototype.format =
+Response.prototype.attachment =
+Response.prototype.append =
+Response.prototype.set =
+Response.prototype.header =
+Response.prototype.get =
+Response.prototype.clearCookie =
+Response.prototype.cookie =
+Response.prototype.location =
+Response.prototype.vary =
+Response.prototype.render =
+Response.prototype.addTrailers =
+Response.prototype.end =
+Response.prototype.getHeader =
+Response.prototype.getHeaderNames =
+Response.prototype.getHeaders =
+Response.prototype.hasHeader =
+Response.prototype.removeHeader =
+Response.prototype.setHeader =
+Response.prototype.setTimeout =
+Response.prototype.write =
+Response.prototype.writeContinue =
+Response.prototype.writeHead =
+noop;

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @file response.js
  * @author Wes Todd

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,3 +1,4 @@
+'use strict';
 /**
  * @file router.js
  * @author Wes Todd

--- a/lib/router.js
+++ b/lib/router.js
@@ -6,7 +6,7 @@
 
 // Requirements
 var BaseRouter = require('router');
-var util = require('util');
+var inherits = require('inherits');
 var url = require('url');
 var qs = require('querystring');
 var Request = require('./request');
@@ -54,7 +54,7 @@ var Router = module.exports = function Router (options) {
 
 	return r;
 };
-util.inherits(Router, BaseRouter);
+inherits(Router, BaseRouter);
 
 /**
  * Set the base path for this router

--- a/lib/router.js
+++ b/lib/router.js
@@ -150,7 +150,7 @@ Router.prototype.onClick = function (e, el) {
 		pathname: el.pathname,
 		search: el.search,
 		hash: el.hash
-	});
+	}, false);
 };
 
 /**
@@ -162,7 +162,7 @@ Router.prototype.onClick = function (e, el) {
  * @param {String} url - The new url for the page
  */
 Router.prototype.changeRoute = function (_url) {
-	this._processRequest(url.parse(_url));
+	this._processRequest(url.parse(_url), false);
 };
 
 /**

--- a/lib/router.js
+++ b/lib/router.js
@@ -30,19 +30,19 @@ var Router = module.exports = function Router (options) {
 	}
 
 	// Options is optional
-	options = options || {};
+	var opts = options || {};
 
 	// Set the base path
-	this.base(options.base || null);
+	this.base(opts.base || null);
 
 	// Keep the currently matched location
 	this.currentLocation = null;
 
 	// Call parent constructor
-	var r = BaseRouter.call(this, options);
+	var r = BaseRouter.call(this, opts);
 
 	// Parse query string
-	if (options.parseQuerystring) {
+	if (opts.parseQuerystring) {
 		r.use(function (req, res, next) {
 			req.query = qs.parse(req._parsedUrl.query);
 			next();
@@ -84,10 +84,10 @@ Router.prototype.base = function (path) {
  */
 Router.prototype.listen = function (options) {
 	// Default options
-	options = options || {};
+	var opts = options || {};
 
 	// Watch for popstate?
-	if (supported && options.popstate !== false) {
+	if (supported && opts.popstate !== false) {
 		// Pre-bind the popstate listener so we can properly remove it later
 		this.onPopstate = this.onPopstate.bind(this);
 
@@ -96,12 +96,12 @@ Router.prototype.listen = function (options) {
 	}
 
 	// Intercept all clicks?
-	if (supported && options.interceptClicks !== false) {
+	if (supported && opts.interceptClicks !== false) {
 		this._stopInterceptingClicks = interceptClicks(this.onClick.bind(this));
 	}
 
 	// Dispatch at start?
-	if (options.dispatch !== false) {
+	if (opts.dispatch !== false) {
 		this._processRequest({
 			pathname: window.location.pathname,
 			search: window.location.search,

--- a/lib/router.js
+++ b/lib/router.js
@@ -155,7 +155,7 @@ Router.prototype.onClick = function (e, el) {
 /**
  * Change the page route
  *
- * @function onClick
+ * @function changeRoute
  * @memberof module:nighthawk.Router
  * @instance
  * @param {String} url - The new url for the page

--- a/lib/router.js
+++ b/lib/router.js
@@ -9,11 +9,20 @@
 var BaseRouter = require('router');
 var inherits = require('inherits');
 var url = require('url');
-var qs = require('querystring');
 var interceptClicks = require('intercept-link-clicks');
 var Request = require('./request');
 var Response = require('./response');
 var supported = require('./supports-push-state');
+
+// Lazy load query string parser
+var qs = {};
+var _qs;
+Object.defineProperty(qs, 'parse', {
+	get: function () {
+		_qs = _qs || require('q' + 's');
+		return _qs.parse;
+	}
+});
 
 /**
  * Router

--- a/lib/router.js
+++ b/lib/router.js
@@ -9,10 +9,10 @@ var BaseRouter = require('router');
 var inherits = require('inherits');
 var url = require('url');
 var qs = require('querystring');
+var interceptClicks = require('intercept-link-clicks');
 var Request = require('./request');
 var Response = require('./response');
 var supported = require('./supports-push-state');
-var interceptClicks = require('intercept-link-clicks');
 
 /**
  * Router

--- a/lib/router.js
+++ b/lib/router.js
@@ -39,6 +39,9 @@ var Router = module.exports = function Router (options) {
 	// Keep the currently matched location
 	this.currentLocation = null;
 
+	// Local variables
+	this.locals = Object.create(null);
+
 	// Call parent constructor
 	var r = BaseRouter.call(this, opts);
 

--- a/lib/supports-push-state.js
+++ b/lib/supports-push-state.js
@@ -1,5 +1,5 @@
 // Coppied from: https://github.com/Modernizr/Modernizr/blob/master/feature-detects/history.js
-module.exports = (function () {
+module.exports = (function (win) {
 	// Issue #733
 	// The stock browser on Android 2.2 & 2.3, and 4.0.x returns positive on history support
 	// Unfortunately support is really buggy and there is no clean way to detect
@@ -15,11 +15,11 @@ module.exports = (function () {
 		ua.indexOf('Windows Phone') === -1 &&
 		// Since all documents on file:// share an origin, the History apis are
 		// blocked there as well
-		window.location.protocol !== 'file:'
+		win.location && win.location.protocol !== 'file:'
 	) {
 		return false;
 	}
 
 	// Return the regular check
-	return (window.history && 'pushState' in window.history);
-})();
+	return (win.history && 'pushState' in win.history);
+})(typeof window !== 'undefined' ? window : {});

--- a/lib/supports-push-state.js
+++ b/lib/supports-push-state.js
@@ -1,3 +1,4 @@
+'use strict';
 // Coppied from: https://github.com/Modernizr/Modernizr/blob/master/feature-detects/history.js
 module.exports = (function (win) {
 	// Issue #733

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nighthawk",
-  "version": "1.4.4",
+  "version": "2.0.0-BETA-1",
   "description": "A client-side wrapper for the Express router",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "author": "Wes Todd",
   "license": "ISC",
   "dependencies": {
+    "inherits": "^2.0.3",
     "intercept-link-clicks": "^1.0.2",
     "router": "^1.1.4"
   },

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "minify": "uglifyjs dist/nighthawk.js -mc -o dist/nighthawk.min.js",
     "gzip": "gzip -c dist/nighthawk.min.js > dist/nighthawk.min.js.gz",
     "size": "stat -f \"File size: %z bytes gzipped\" dist/nighthawk.min.js.gz",
-    "test": "happiness && mochify --grep 'BROWSER: ' --invert",
+    "test": "happiness && mochify -r qs --grep 'BROWSER: ' --invert",
     "test-cover": "mochify --cover",
-    "test-browser": "happiness && mochify --wd",
+    "test-browser": "happiness && mochify --wd -r qs",
     "example-basic": "cd example/basic && npm install && npm run browserify && npm run start",
     "example-basedir": "cd example/base-dir && npm install && npm run browserify && npm run start",
     "example-redirect": "cd example/redirect && npm install && npm run browserify && npm run start",
@@ -43,7 +43,8 @@
     "browserify": "^14.1.0",
     "disc": "^1.3.2",
     "happiness": "^7.1.2",
-    "mochify": "^3.1.0",
+    "mochify": "^3.1.1",
+    "qs": "^6.4.0",
     "uglify-js": "^2.8.16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nighthawk",
-  "version": "2.0.0-BETA-2",
+  "version": "2.0.0-BETA-3",
   "description": "A client-side wrapper for the Express router",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "example-basic": "cd example/basic && npm install && npm run browserify && npm run start",
     "example-basedir": "cd example/base-dir && npm install && npm run browserify && npm run start",
     "example-redirect": "cd example/redirect && npm install && npm run browserify && npm run start",
-    "prepublish": "npm t",
+    "prepublish": "npm run dist && npm t",
     "postpublish": "git push && git push --tags"
   },
   "author": "Wes Todd",
@@ -39,10 +39,10 @@
     "url": "git://github.com/wesleytodd/nighthawk.git"
   },
   "devDependencies": {
-    "browserify": "^13.0.0",
+    "browserify": "^14.1.0",
     "disc": "^1.3.2",
-    "happiness": "JedWatson/happiness",
-    "mochify": "^2.15.0",
-    "uglifyjs": "^2.4.10"
+    "happiness": "^7.1.2",
+    "mochify": "^3.1.0",
+    "uglify-js": "^2.8.16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nighthawk",
-  "version": "2.0.0-BETA-1",
+  "version": "2.0.0-BETA-2",
   "description": "A client-side wrapper for the Express router",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "example": "example"
   },
   "scripts": {
-    "dist": "mkdir -p dist && npm run build && npm run minify && npm run gzip && npm run size",
+    "dist": "mkdir -p dist && npm run build && npm run minify && npm run gzip",
     "disc": "mkdir -p dist && npm run build-dev && npm run minify && discify dist/nighthawk.min.js -O && npm run gzip && npm run size",
     "build": "browserify index.js -s Nighthawk -o dist/nighthawk.js",
     "build-dev": "browserify index.js --full-paths -u buffer -u url -u util -u process -o dist/nighthawk.js",
@@ -21,7 +21,7 @@
     "size": "stat -f \"File size: %z bytes gzipped\" dist/nighthawk.min.js.gz",
     "test": "happiness && mochify --grep 'BROWSER: ' --invert",
     "test-cover": "mochify --cover",
-    "test-browser": "mochify --wd",
+    "test-browser": "happiness && mochify --wd",
     "example-basic": "cd example/basic && npm install && npm run browserify && npm run start",
     "example-basedir": "cd example/base-dir && npm install && npm run browserify && npm run start",
     "example-redirect": "cd example/redirect && npm install && npm run browserify && npm run start",

--- a/test/request.js
+++ b/test/request.js
@@ -1,0 +1,10 @@
+/* global describe, it */
+var Request = require('../lib/request');
+var assert = require('assert');
+
+describe('Request', function () {
+	it('should have the correct protocol', function () {
+		var r = new Request();
+		assert.equal(r.protocol, 'http');
+	});
+});

--- a/test/request.js
+++ b/test/request.js
@@ -6,5 +6,10 @@ describe('Request', function () {
 	it('should have the correct protocol', function () {
 		var r = new Request();
 		assert.equal(r.protocol, 'http');
+		assert.equal(r.secure, false);
+	});
+	it('should have the correct hostname', function () {
+		var r = new Request();
+		assert.equal(r.hostname, window.location.hostname);
 	});
 });

--- a/test/router.js
+++ b/test/router.js
@@ -9,7 +9,7 @@ describe('Router', function () {
 			window.history.pushState('/', null, '/');
 			router.destroy();
 		}
-		router = Router();
+		router = new Router();
 
 		evt = {
 			which: 1,
@@ -119,5 +119,17 @@ describe('Router', function () {
 		};
 
 		router.changeRoute('/foo?bar=bar#baz');
+	});
+
+	it('should parse the query string', function (done) {
+		router = new Router({
+			parseQuerystring: true
+		});
+
+		router.use(function (req, res) {
+			assert.equal(req.query.foo, 'bar');
+			done();
+		});
+		router.changeRoute('/test?foo=bar');
 	});
 });

--- a/test/router.js
+++ b/test/router.js
@@ -6,6 +6,7 @@ describe('Router', function () {
 	var router, evt;
 	beforeEach(function () {
 		if (router) {
+			window.history.pushState('/', null, '/');
 			router.destroy();
 		}
 		router = Router();
@@ -38,8 +39,8 @@ describe('Router', function () {
 	});
 
 	it('BROWSER: should start listening to changes', function (done) {
-		router.get('/webdriver.html', function (req, res) {
-			assert.equal(req.path, '/webdriver.html', 'Did not match route path correctly');
+		router.get('/', function (req, res) {
+			assert.equal(req.path, '/', 'Did not match route path correctly');
 			done();
 		});
 
@@ -49,7 +50,7 @@ describe('Router', function () {
 	});
 
 	it('BROWSER: should process route on popstate', function (done) {
-		router.get('/webdriver.html', function (req, res) {
+		router.get('/', function (req, res) {
 			done();
 		});
 


### PR DESCRIPTION
Changes:

- Lazy load `qs` module instead of requiring `querystring` (breaking change)
- Added all the other `Request` object methods and properties
- Added all the other `Response` object methods and properties
- Updated dev deps
- Use `inherits` module instead of `util`
- Added `.locals` to router
- Added support for using `get` and `header` to get `referrer` and `content-type`
- Patches: fd91171, 6538a78, eef1cb7, 3b58772, 365cd31, 0da2337, 1cb0a4f, 974746a, 5adb024, 45ae656e946be07ae6d67431d10f2514dbca8364